### PR TITLE
Towards a common SHACL base

### DIFF
--- a/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-impliedRules.ttl
+++ b/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-impliedRules.ttl
@@ -473,6 +473,16 @@
 # .
 
 # Konv 30: Werden, wie empfohlen, Kategorien verwendet, MÜSSEN die MDR data themes genutzt werden. - Seite 20
+
+:DCATAPde_themes
+    a sh:NodeShape ;
+    sh:targetClass dcat:theme ;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://publications.europa.eu/resource/authority/data-theme>;
+    ];
+.
+
 :Shapes_ImplR_Konv_30 
     a sh:NodeShape ;
     sh:targetClass dcat:Dataset ;
@@ -482,32 +492,29 @@
     sh:deactivated false ;
 
     sh:property [
-        sh:path dcat:theme ;
-        sh:node [
-            sh:hasValue <http://publications.europa.eu/resource/authority/data-theme> ;
-            sh:nodeKind sh:IRI ;
-            sh:path skos:inScheme ;
-        ] ;
+        sh:path dcat:theme;
+        sh:node :DCATAPde_themes;
 
         sh:severity sh:Violation ;
         sh:message "Pflicht (K30): Werden, wie empfohlen, Kategorien verwendet, MÜSSEN die MDR data themes genutzt werden. - Seite 20" ;
     ] ;
 .
 
-# # Konv 31: Hat die Datei, die die Daten einer Distribution beinhaltet, einen in der MDR authority file table geführten mediaType, so MUSS auf diesen mittels dct:format verwiesen werden. Andernfalls MUSS via dcat:mediaType auf die IANA Liste verwiesen und ein ggf. fehlender mediaType dort angelegt werden. - Seite 22
-# :Shapes_ImplR_Konv_31 
-#     a sh:NodeShape ; 
-#     #sh:target... 
-#     sh:name "Konvention 31"@de ; 
-#     sh:description "Hat die Datei, die die Daten einer Distribution beinhaltet, einen in der MDR authority file table geführten mediaType, so MUSS auf diesen mittels dct:format verwiesen werden. Andernfalls MUSS via dcat:mediaType auf die IANA Liste verwiesen und ein ggf. fehlender mediaType dort angelegt werden. - Seite 22" ;
-#     sh:deactivated true ;
-#     #... tbd ...
-# .
 
 # Konv 32: Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23
     # Diese Konvention bezieht sich nur auf Lizenzen einer Distribution, auch Catalog kann dct:license verwenden, auch dort wäre anzunehmen, dass unsere URIs verwendet werden müssen.
     # 1. Lizenz muss vorhanden sein
     # 2. Lizenz muss DCAT-AP.de Lizenz sein
+
+:DCATAPde_license
+    a sh:NodeShape ;
+    sh:targetClass dct:license ;
+    sh:property [
+        sh:path skos:inScheme ;
+        sh:hasValue <http://dcat-ap.de/def/licenses> ;
+    ];
+.
+
 :Shapes_ImplR_Konv_32 
     a sh:NodeShape ; 
     sh:targetClass dcat:Distribution ;
@@ -520,20 +527,27 @@
         sh:minCount 1 ;
 
         sh:severity sh:Violation ;
-        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23" ;
+        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23: Keine Lizenz angegeben" ;
     ] ;
 
     sh:property [
         sh:path dct:license ;
-        sh:node [
-            sh:hasValue <http://dcat-ap.de/def/licenses> ;
-            # sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:path skos:inScheme ;
-        ] ;
+        sh:nodeKind sh:IRI ;
 
         sh:severity sh:Violation ;
-        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23" ;
+        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23. Lizenz ist keine URI" ;
+    ] ;
+
+    sh:property [
+        sh:path dct:license ;
+
+	    sh:qualifiedValueShape [
+            sh:node :DCATAPde_license;
+	    ];
+	    sh:qualifiedMinCount 1 ;
+
+        sh:severity sh:Violation ;
+        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23. Nicht passende Lizenz" ;
     ] ;
 .
 

--- a/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-impliedRules.ttl
+++ b/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-impliedRules.ttl
@@ -476,7 +476,7 @@
 
 :DCATAPde_themes
     a sh:NodeShape ;
-    sh:targetClass dcat:theme ;
+    sh:targetClass skos:Concept ;
     sh:property [
         sh:path skos:inScheme ;
         sh:hasValue <http://publications.europa.eu/resource/authority/data-theme>;
@@ -508,7 +508,7 @@
 
 :DCATAPde_license
     a sh:NodeShape ;
-    sh:targetClass dct:license ;
+    sh:targetClass dct:LicenseDocument ;
     sh:property [
         sh:path skos:inScheme ;
         sh:hasValue <http://dcat-ap.de/def/licenses> ;

--- a/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-specification.ttl
+++ b/validator/resources/v1.0.2/shapes/dcat-ap-de-shapes-specification.ttl
@@ -12,7 +12,7 @@
 # Alternativ kann folgendes angehängt werden, um die (überarbeitete) Beispieldatei zu validieren:
 # -contentToValidate ../testcases/rewritten-example-advanced.ttl
 
-@prefix : <http://dcat-ap.de/def/dcatde/1.0.2/#>
+@prefix : <http://dcat-ap.de/def/dcatde/1.0.2/#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .


### PR DESCRIPTION
Hi GovData!

You made a tremendous step forward here! At least a silver stripe for a BRD wide uniform validation of DCAT-AP.de approaches  the horizon. We maintained a Python based DCAT-AP-de (2000 LOC) parser for 4 years and it sucks.

We at BBG will enters the SHACL challenge, now. We will utilizing Python (PySHACL) to validate the BBG open data with the help of the SHACL-Files of this repository. Others are obviously utilizing JAVA code for the validation. Utilizing this Repo from two different languages will make it more compatible for the use of all. 

We contribute:

0) I fixed a minor bug - missing dot - in dcat-ap-de-shapes-specification.ttl, which your parser obviously just ignored.

Also I enhanced the checking for dct:license and dcat:theme. 
1) The former code defined an implicit NodeShape for Rule 30 and 32 which may be OK with certain parsers:

```
    sh:property [
        sh:path dct:license ;
        sh:node [
            sh:hasValue <http://dcat-ap.de/def/licenses> ;
            # sh:minCount 1 ;
            sh:nodeKind sh:IRI ;
            sh:path skos:inScheme ;
        ] ;

        sh:severity sh:Violation ;
        sh:message "Pflicht (K32): Distributionen von Datensätzen MÜSSEN mit einer Lizenz ausgewiesen werden. Für die Kennzeichnung der im Abschnitt 2.1 aufgeführten Lizenzen MÜSSEN die dort genannten URIs verwendet werden. - Seite 23" ;
    ] ;
.
```
PySHACLE is more on the safety-side and refused to work on these implicit not well defined shapes.

But IMHO the implict NodeShapes were broken nevertheless: An RDF-Node may be an IRI but then it may not have at the same time properties like skos:inScheme. 

**To clarify I made these implicit NodeShapes explicit. Have a look at the diff, please.**

2) The logic of the shape for dct:license is IMHO to strict: At least one License and ANY license conform to DCAT-AP.de? Dual-Licensing is quite common. I moderated this to: At least one License that conforms to DCAT-AP.de.

3) Also I like to mention that the current SHACL code is doing validation not by Lenins measure : "Trust is good, control is better". 

The following dcat:distribution:

```
<https://opendata.potsdam.de/api/v2/catalog/datasets/3d-gebaudemodell-lod2-citygml-csv> a dcat:Distribution ;
   <dct:license <https://inqbus.de/evil_license>;
   <skos:inScheme dct:license <https://inqbus.de/evil_license>;
```

will pass the current validation while it is obviously rubbish since 

`dct:license <https://inqbus.de/evil_license>`

is not in <http://dcat-ap.de/def/licenses>

3.1) In the "DCAT-AP.de convention handbook" there is not even a mentioning of a required skos:inScheme property for the dct-license. So basing the check for dct:license compliance on this property is fruitless. 
3.2) A better validation would be to check the URI of the license against the URIs from DCAT-AP.de. This could be done by some SPARQL in the SHACL code.


Cheers,
Volker


