### PR TITLE
Support for English

### DIFF
--- a/validator/resources/config.properties
+++ b/validator/resources/config.properties
@@ -1,17 +1,6 @@
 # The different types of validation to support. These values are reflected in other properties.
 validator.type = v11_de_spec, v210d_ap_man, v210d_ap_manrec, v210d_ap_man_v11_de_spec, v210d_ap_manrec_v11_de_spec, v11_de_konv, all, dashboard_alpha, dashboard_live
 
-# Labels to describe the defined types.
-validator.typeLabel.v11_de_spec                 = DCAT-AP.de 1.1 - Spezifikation (1.1)
-validator.typeLabel.v210d_ap_man                = DCAT-AP 2.1 - Mandatory (Auswahl)
-validator.typeLabel.v210d_ap_manrec             = DCAT-AP 2.1 - Mandatory & Recommended (Auswahl)
-validator.typeLabel.v210d_ap_man_v11_de_spec    = DCAT-AP.de 1.1 Spezifikation + DCAT-AP 2.1 Mandatory
-validator.typeLabel.v210d_ap_manrec_v11_de_spec = DCAT-AP.de 1.1 Spezifikation + DCAT-AP 2.1 Mandatory & Recommended
-validator.typeLabel.v11_de_konv                 = DCAT-AP.de 1.1 GovData-Konventionen (1, 2, 4-12, 21, 30, 32)
-validator.typeLabel.all                         = DCAT-AP.de 1.1 Spezifikation + GovData-Konventionen (s.o.) + DCAT-AP 2.1 Mandatory & Recommended
-validator.typeLabel.dashboard_alpha             = GovData MQA (Alpha)
-validator.typeLabel.dashboard_live              = GovData Dashboard Qualitätsmerkmale
-
 ##################################################################################
 # 1 "DCAT-AP.de - nur Spezifikation" validation artefacts
 ##################################################################################
@@ -143,44 +132,7 @@ validator.queryEndpoint = https://www.govdata.de/sparql
 # Set ordering of the results
 validator.reportsOrdered = true
 
-# The title to display for the validator's user interface.
-validator.uploadTitle = DCAT-AP.de Validator (BETA)
-
-# The banner for the validator
-validator.bannerHtml = <div class="alert alert-warning" role="alert">&#x1f6c8; <strong>Beta-Version! Feedback gewünscht!</strong> Bitte als Issue im <a class="alert-link" href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/issues">GitHub-Repository</a> oder per E-Mail an <a class="alert-link" href="mailto:info@govdata.de">info@govdata.de</a>!</div> <div class="row"> <div class="col-xs-12 col-sm-4 col-md-3 text-center"><img style="margin-bottom: 15px; width: 80%;" alt="DCAT-AP.de Logo" src="https://www.dcat-ap.de/assets/dcatapde.png"></div> <div class="col-xs-12 col-sm-8 col-md-9"> <h2 class="text-center" style="margin-top: 0;">DCAT-AP.de Validator (BETA)</h2></div> </div> <div class="row"> <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-9 col-md-offset-3"> <p>Hinweis: Dies ist die Beta eines <strong><a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a></strong> SHACL-Validators. Insbesondere werden die Eigenschaften überprüft, die das deutsche <a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a> Spezifikationsdokument zusätzlich oder abweichend vom europäischen <a href="https://github.com/SEMICeu/DCAT-AP">DCAT-AP 1.2.1 Standard</a> festlegt. Um eine vollständige Validierung von DCAT.AP.de zu ermöglichen, werden derzeit die SHACL-Shapes von DCAT-AP angepasst und eingebunden.</p> <p>Eine Liste der überprüften Eigenschaften des Spezifikationsdokuments (noch nicht des Konventionenhandbuchs!) und weitere Informationen zu diesem Validator finden Sie unter: <a href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/">https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/</a>.</p> <p>Eine Kurzanleitung zum Validator finden Sie unter: <a href="https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator">https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator</a>.</p> </div> </div> 
-
-# Localization
-validator.reportTitle = Validierungsbericht
-validator.label.fileInputLabel = Zu validierender Inhalt
-validator.label.fileInputPlaceholder = Datei auswählen...
-validator.label.typeLabel = Zu verwendendes Profil
-validator.label.contentSyntaxLabel = Syntax des Inhalts
-validator.label.contentSyntaxTooltip = Optional, wenn die Datei oder URI eine bekannte Dateiendung verwendet.
-validator.label.includeExternalShapes = Externe Shapes einfügen
-validator.label.externalRulesTooltip = Externe Shapes die, zusätzlich zu denen des gewählten Profils zur Validierung genutzt werden sollen.
-validator.label.externalShapesLabel = Externe Shapes
-validator.label.optionContentFile = Datei
-validator.label.optionContentURI = URI
-validator.label.optionContentDirectInput = Direkte Eingabe
-validator.label.uploadButton = Validieren
-validator.label.resultSectionTitle = Validierungsergebnis
-validator.label.resultSubSectionOverviewTitle = Überblick
-validator.label.resultDateLabel = Zeitpunkt:
-validator.label.resultFileNameLabel = Dateiname:
-validator.label.resultValidationTypeLabel = Verwendetes Profil:
-validator.label.resultResultLabel = Ergebnis:
-validator.label.resultErrorsLabel = Fehler (Violation):
-validator.label.resultWarningsLabel = Warnungen (Warning):
-validator.label.resultMessagesLabel = Nachrichten (Info):
-validator.label.resultSubSectionDetailsTitle = Details
-validator.label.resultTestLabel = Test:
-validator.label.resultLocationLabel = Ort:
-validator.label.optionDownloadReport = Validierungsbericht
-validator.label.optionDownloadContent = Validierter Inhalt
-validator.label.optionDownloadShapes = Shapes
-validator.label.saveDownload = Download
-validator.label.saveAs = als
-validator.label.reportItemFocusNode = Fokusknoten
-validator.label.reportItemResultPath = Ergebnispfad
-validator.label.reportItemShape = Shape
-validator.label.reportItemValue = Wert
+# Language settings
+validator.locale.default = de
+validator.locale.available = de,en
+validator.locale.translations = translations

--- a/validator/resources/translations/labels_de.properties
+++ b/validator/resources/translations/labels_de.properties
@@ -1,0 +1,24 @@
+# Labels to describe the defined types.
+validator.typeLabel.v11_de_spec                 = DCAT-AP.de 1.1 - Spezifikation (1.1)
+validator.typeLabel.v210d_ap_man                = DCAT-AP 2.1 - Mandatory (Auswahl)
+validator.typeLabel.v210d_ap_manrec             = DCAT-AP 2.1 - Mandatory & Recommended (Auswahl)
+validator.typeLabel.v210d_ap_man_v11_de_spec    = DCAT-AP.de 1.1 Spezifikation + DCAT-AP 2.1 Mandatory
+validator.typeLabel.v210d_ap_manrec_v11_de_spec = DCAT-AP.de 1.1 Spezifikation + DCAT-AP 2.1 Mandatory & Recommended
+validator.typeLabel.v11_de_konv                 = DCAT-AP.de 1.1 GovData-Konventionen (1, 2, 4-12, 21, 30, 32)
+validator.typeLabel.all                         = DCAT-AP.de 1.1 Spezifikation + GovData-Konventionen (s.o.) + DCAT-AP 2.1 Mandatory & Recommended
+validator.typeLabel.dashboard_alpha             = GovData MQA (Alpha)
+validator.typeLabel.dashboard_live              = GovData Dashboard Qualitätsmerkmale
+
+# The title to display for the validator's user interface.
+validator.uploadTitle = DCAT-AP.de Validator (BETA)
+
+# The banner for the validator
+validator.bannerHtml = <div class="alert alert-warning" role="alert">&#x1f6c8; <strong>Beta-Version! Feedback gewünscht!</strong> Bitte als Issue im <a class="alert-link" href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/issues">GitHub-Repository</a> oder per E-Mail an <a class="alert-link" href="mailto:info@govdata.de">info@govdata.de</a>!</div> <div class="row"> <div class="col-xs-12 col-sm-4 col-md-3 text-center"><img style="margin-bottom: 15px; width: 80%;" alt="DCAT-AP.de Logo" src="https://www.dcat-ap.de/assets/dcatapde.png"></div> <div class="col-xs-12 col-sm-8 col-md-9"> <h2 class="text-center" style="margin-top: 0;">DCAT-AP.de Validator (BETA)</h2></div> </div> <div class="row"> <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-9 col-md-offset-3"> <p>Hinweis: Dies ist die Beta eines <strong><a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a></strong> SHACL-Validators. Insbesondere werden die Eigenschaften überprüft, die das deutsche <a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a> Spezifikationsdokument zusätzlich oder abweichend vom europäischen <a href="https://github.com/SEMICeu/DCAT-AP">DCAT-AP 1.2.1 Standard</a> festlegt. Um eine vollständige Validierung von DCAT.AP.de zu ermöglichen, werden derzeit die SHACL-Shapes von DCAT-AP angepasst und eingebunden.</p> <p>Eine Liste der überprüften Eigenschaften des Spezifikationsdokuments (noch nicht des Konventionenhandbuchs!) und weitere Informationen zu diesem Validator finden Sie unter: <a href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/">https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/</a>.</p> <p>Eine Kurzanleitung zum Validator finden Sie unter: <a href="https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator">https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator</a>.</p> </div> </div> 
+
+# Localization
+validator.label.typeLabel = Zu verwendendes Profil
+validator.label.externalRulesTooltip = Externe Shapes die, zusätzlich zu denen des gewählten Profils zur Validierung genutzt werden sollen.
+validator.label.resultValidationTypeLabel = Verwendetes Profil:
+validator.label.resultErrorsLabel = Fehler (Violation):
+validator.label.resultWarningsLabel = Warnungen (Warning):
+validator.label.resultMessagesLabel = Nachrichten (Info):

--- a/validator/resources/translations/labels_en.properties
+++ b/validator/resources/translations/labels_en.properties
@@ -1,0 +1,24 @@
+# Labels to describe the defined types.
+validator.typeLabel.v11_de_spec                 = DCAT-AP.de 1.1 - Specification (1.1)
+validator.typeLabel.v210d_ap_man                = DCAT-AP 2.1 - Mandatory (Selection)
+validator.typeLabel.v210d_ap_manrec             = DCAT-AP 2.1 - Mandatory & Recommended (Selection)
+validator.typeLabel.v210d_ap_man_v11_de_spec    = DCAT-AP.de 1.1 Specification + DCAT-AP 2.1 Mandatory
+validator.typeLabel.v210d_ap_manrec_v11_de_spec = DCAT-AP.de 1.1 Specification + DCAT-AP 2.1 Mandatory & Recommended
+validator.typeLabel.v11_de_konv                 = DCAT-AP.de 1.1 GovData-Guidelines (1, 2, 4-12, 21, 30, 32)
+validator.typeLabel.all                         = DCAT-AP.de 1.1 Specification + GovData-Guidelines (s.o.) + DCAT-AP 2.1 Mandatory & Recommended
+validator.typeLabel.dashboard_alpha             = GovData MQA (Alpha)
+validator.typeLabel.dashboard_live              = GovData Quality Dashboard
+
+# The title to display for the validator's user interface.
+validator.uploadTitle = DCAT-AP.de Validator (BETA)
+
+# The banner for the validator
+validator.bannerHtml = <div class="alert alert-warning" role="alert"> 🛈 <strong>Beta version! Feedback wanted!</strong> Please provide issues in the <a class="alert-link" href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/issues">GitHub repository</a> or by email to <a class="alert-link" href="mailto:info@govdata.de">info@govdata.de</a>! </div><div class="row"> <div class="col-xs-12 col-sm-4 col-md-3 text-center"><img style="margin-bottom: 15px; width: 80%;" alt="DCAT-AP.de Logo" src="https://www.dcat-ap.de/assets/dcatapde.png"/></div><div class="col-xs-12 col-sm-8 col-md-9"><h2 class="text-center" style="margin-top: 0;">DCAT-AP.de Validator (BETA)</h2></div></div><div class="row"> <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-9 col-md-offset-3"> <p> Note: This is the beta of a <strong><a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a></strong> SHACL validator. In particular, the properties are checked against those specified in the German <a href="https://www.dcat-ap.de/def/">DCAT-AP.de 1.0.2</a> specification document, in addition to or deviating from the European <a href="https://github.com/SEMICeu/DCAT-AP">DCAT-AP 1.2.1 standard</a>. In order to enable a complete validation of DCAT.AP.de, the SHACL shapes of DCAT-AP are currently being adapted and integrated. </p><p> A list of the validated properties of the specification document (not yet the convention manual!) and more information about this validator can be found at: <a href="https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/">https://github.com/GovDataOfficial/DCAT-AP.de-SHACL-Validation/</a>. </p><p> A quick guide for the validator can be found at: <a href="https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator">https://www.itb.ec.europa.eu/docs/guides/latest/validatingRDF/index.html#step-6-use-the-validator</a>. </p></div></div>
+
+# Localization
+validator.label.typeLabel = Profile to use
+validator.label.externalRulesTooltip = External shapes that should be used for validation in addition to those of the selected profile.
+validator.label.resultValidationTypeLabel = Profile used:
+validator.label.resultErrorsLabel = Errors (Violation):
+validator.label.resultWarningsLabel = Warnings (Warning):
+validator.label.resultMessagesLabel = Messages (Info):


### PR DESCRIPTION
Adapted the DCAT-AP.de validator configuration to support English alongside German (which remains the validator's default language). As part of this update:
- Translation-related properties were removed from the **config.properties** file.
- Translations for English and German were moved to separate translation files (**labels_en.properties** and **labels_de.properties**). The **config.properties** file was extended to refer to these and define the available languages.
- Unnecessary label translations previously defined in **config.properties** were now removed. Any texts that did not match the validator's default translations have been maintained to ensure the result for German remains identical.

Making this update also resolved some remaining translation issues of the current version. Such examples are the "about" footer and the "busy" message that is displayed while validation is being carried out.

**Important:** The current pull request covers only the validator's texts and labels. To have complete support for both English and German you would still need to add relevant translations to the SHACL shape files. This is done by adding language-specific **sh:message** entries for each shape.

For example, taking a shape such as the following:

```
    sh:property [
        sh:severity sh:Violation ;
        sh:message "Pflicht (K12): Alle Datenstrukturen, die direkt an das GovData Portal geliefert werden, MÜSSEN ihre Herkunft über eine eindeutige Kennzeichnung des Datenbereitstellers über die DatenbereitstellerID (dcatde:contributorID) ausweisen. - Seite 13"; 
        sh:path dcatde:contributorID ;
        sh:minCount 1 ;
    ]
```

it would need to be adapted to define an sh:message for each language as follows:

```
    sh:property [
        sh:severity sh:Violation ;
        sh:message "Pflicht (K12): Alle Datenstrukturen, die direkt an das GovData Portal geliefert werden, MÜSSEN ihre Herkunft über eine eindeutige Kennzeichnung des Datenbereitstellers über die DatenbereitstellerID (dcatde:contributorID) ausweisen. - Seite 13"@de ; 
        sh:message "Mandatory (K12): All data structures that are delivered directly to the GovData Portal MUST identify their origin by clearly identifying the data provider using the data provider ID (dcatde:contributorID). - Page 13"@en ; 
        sh:path dcatde:contributorID ;
        sh:minCount 1 ;
    ]
```

Without updating the shapes as described, the produced reports will remain identical to what is currently produced. This means that although a user has selected English on the UI, the produced reports will still contain German messages.

Needless to say, this PR relates to adding English support, but extending further for additional languages is a matter of adding the language to the configuration, adding its translation file, and adding the relevant sh:messages to the shapes. All official EU languages can be added easily in this way.

